### PR TITLE
only import necessary ethers module

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,9 +24,9 @@
     "react": ">=16.8"
   },
   "dependencies": {
+    "@ethersproject/providers": "^5.4.5",
     "@types/react-blockies": "^1.4.1",
     "color": "^3.2.1",
-    "ethers": "^5.4.6",
     "mersenne-twister": "^1.1.0",
     "react-blockies": "^1.4.1"
   }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { Web3Provider, getDefaultProvider } from '@ethersproject/providers';
 import React, { useEffect, useState } from 'react';
 
 import Image from './Image';
@@ -18,7 +18,7 @@ export default function Davatar({ size, address, provider, graphApiKey, generate
   const [avatarUri, setAvatarUri] = useState<string | null>(null);
 
   useEffect(() => {
-    const eth = provider ? new ethers.providers.Web3Provider(provider) : ethers.getDefaultProvider();
+    const eth = provider ? new Web3Provider(provider) : getDefaultProvider();
     eth.lookupAddress(address).then(ensName => {
       if (ensName) {
         eth.getResolver(ensName).then(resolver => {


### PR DESCRIPTION
Limits imports to the `@ethersproject/providers` module.

Importing as `import { ethers } from 'ethers';` and then using `ethers.providers` prevented tree-shaking from removing the unused portions of the `ethers` library. Only `@ethersproject/providers` is actually used.