### PR TITLE
Add optional defaultComponent prop to davatar image component

### DIFF
--- a/packages/react/example/src/App.jsx
+++ b/packages/react/example/src/App.jsx
@@ -8,6 +8,11 @@ function App() {
       <header className="App-header">
         <Davatar size={120} address={'0x9B6568d72A6f6269049Fac3998d1fadf1E6263cc'} />
         <Davatar size={120} address={'0x9B6568d72A6f6269049Fac3998d1fadf1E6263cc'} generatedAvatarType="blockies" />
+        <Davatar
+          size={120}
+          address={'0x9B6568d72A6f6269049Fac3998d1fadf1E6263cc'}
+          defaultComponent={<h2>Loading...</h2>}
+        />
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>

--- a/packages/react/src/Image.tsx
+++ b/packages/react/src/Image.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, CSSProperties } from 'react';
+import React, { useState, useEffect, useCallback, CSSProperties, ReactChild } from 'react';
 
 import Blockies from './Blockies';
 import Jazzicon from './Jazzicon';
@@ -12,9 +12,19 @@ export interface Props {
   // 698d3c5351720e4ca3a363dbd33d76d2
   graphApiKey?: string;
   generatedAvatarType?: 'jazzicon' | 'blockies';
+  defaultComponent?: ReactChild | ReactChild[];
 }
 
-export default function Avatar({ uri, style, className, size, address, graphApiKey, generatedAvatarType }: Props) {
+export default function Avatar({
+  uri,
+  style,
+  className,
+  size,
+  address,
+  graphApiKey,
+  generatedAvatarType,
+  defaultComponent,
+}: Props) {
   const [url, setUrl] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -195,11 +205,12 @@ export default function Avatar({ uri, style, className, size, address, graphApiK
   const defaultAvatar =
     (!url || !loaded) &&
     address &&
-    (generatedAvatarType === 'blockies' ? (
-      <Blockies address={address} size={size} />
-    ) : (
-      <Jazzicon address={address} size={size} />
-    ));
+    (defaultComponent ||
+      (generatedAvatarType === 'blockies' ? (
+        <Blockies address={address} size={size} />
+      ) : (
+        <Jazzicon address={address} size={size} />
+      )));
 
   return (
     <>

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,5 +1,5 @@
 import { ethers } from 'ethers';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactChild } from 'react';
 
 import Image from './Image';
 
@@ -12,9 +12,17 @@ export interface DavatarProps {
   provider?: any;
   graphApiKey?: string;
   generatedAvatarType?: 'jazzicon' | 'blockies';
+  defaultComponent?: ReactChild | ReactChild[];
 }
 
-export default function Davatar({ size, address, provider, graphApiKey, generatedAvatarType }: DavatarProps) {
+export default function Davatar({
+  size,
+  address,
+  provider,
+  graphApiKey,
+  generatedAvatarType,
+  defaultComponent,
+}: DavatarProps) {
   const [avatarUri, setAvatarUri] = useState<string | null>(null);
 
   useEffect(() => {
@@ -39,6 +47,7 @@ export default function Davatar({ size, address, provider, graphApiKey, generate
       uri={avatarUri}
       graphApiKey={graphApiKey}
       generatedAvatarType={generatedAvatarType}
+      defaultComponent={defaultComponent}
     />
   );
 }


### PR DESCRIPTION
This adds optional `defaultComponent` prop to default export & `Image` component. This will be used instead of a Jassicon or Blockie if present when an ENS avatar is not present for the given wallet address.