### PR TITLE
memoize the RPC provider in useAvatarEthersProvider

### DIFF
--- a/packages/react/src/AvatarProvider.tsx
+++ b/packages/react/src/AvatarProvider.tsx
@@ -40,16 +40,19 @@ export function AvatarProvider({ provider, batchLookups, children }: AvatarProvi
   return <AvatarContext.Provider value={{ provider: finalProvider }}>{children}</AvatarContext.Provider>;
 }
 
-export function useAvatarEthersProvider(provider?: BaseProvider) {
+export function useAvatarEthersProvider(provider?: BaseProvider | null) {
   const avatarContext = useContext(AvatarContext);
+  const defaultProvider = useMemo(() => {
+    if (!avatarContext) {
+      if (provider) {
+        return provider;
+      }
 
-  if (!avatarContext) {
-    if (provider) {
-      return provider;
+      return getDefaultProvider();
     }
 
-    return getDefaultProvider();
-  }
+    return avatarContext.provider;
+  }, [avatarContext, provider]);
 
-  return avatarContext.provider;
+  return defaultProvider;
 }

--- a/packages/react/src/Image.tsx
+++ b/packages/react/src/Image.tsx
@@ -1,7 +1,7 @@
 import { Contract } from '@ethersproject/contracts';
 import { BaseProvider } from '@ethersproject/providers';
 import BigNumber from 'bn.js';
-import React, { useState, useEffect, useCallback, useMemo, CSSProperties, ReactChild } from 'react';
+import React, { useState, useEffect, useCallback, CSSProperties, ReactChild } from 'react';
 
 import { useAvatarEthersProvider } from './AvatarProvider';
 import Blockies from './Blockies';
@@ -76,8 +76,8 @@ export default function Image({
 }: ImageProps) {
   const [url, setUrl] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
-  const avatarEthersProvider = useAvatarEthersProvider();
-  const ethersProvider = useMemo(() => provider || avatarEthersProvider, [provider, avatarEthersProvider]);
+  const avatarEthersProvider = useAvatarEthersProvider(provider);
+  const ethersProvider = avatarEthersProvider;
 
   useEffect(() => {
     if (!uri && address) {

--- a/packages/react/src/docs/Homepage.stories.mdx
+++ b/packages/react/src/docs/Homepage.stories.mdx
@@ -9,6 +9,8 @@ export const provider = getDefaultProvider(1, { infura: '8c5c39d38539467bb5ac522
 
 # How to use davatar
 
+## With AvatarProvider
+
 <Canvas>
   <AvatarProvider provider={provider} batchLookups={true}>
     <Davatar size={120} address={'0x9B6568d72A6f6269049Fac3998d1fadf1E6263cc'} />
@@ -31,4 +33,10 @@ export const provider = getDefaultProvider(1, { infura: '8c5c39d38539467bb5ac522
       defaultComponent={<h2>Loading...</h2>}
     />
   </AvatarProvider>
+</Canvas>
+
+## Without AvatarProvider
+
+<Canvas>
+  <Davatar size={120} address={'0x9B6568d72A6f6269049Fac3998d1fadf1E6263cc'} />
 </Canvas>


### PR DESCRIPTION
This was causing possible infinite loops when not utilizing `<AvatarProvider />` due to not memoizing the default Ethers provider created if no providers are specified.

Fixes #21 and #26
